### PR TITLE
(refactor) Use Compass for production build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,35 +213,30 @@ module.exports = function (grunt) {
       }
     },
 
-    // *** Replaced with grunt-sass
+    // Only runs for dist build
     // Compiles Sass to CSS and generates necessary files if requested
-    // compass: {
-    //   options: {
-    //     sassDir: '<%= yeoman.app %>/styles',
-    //     cssDir: '.tmp/styles',
-    //     generatedImagesDir: '.tmp/images/generated',
-    //     imagesDir: '<%= yeoman.app %>/images',
-    //     javascriptsDir: '<%= yeoman.app %>/scripts',
-    //     fontsDir: '<%= yeoman.app %>/styles/fonts',
-    //     importPath: './bower_components',
-    //     httpImagesPath: '/images',
-    //     httpGeneratedImagesPath: '/images/generated',
-    //     httpFontsPath: '/styles/fonts',
-    //     relativeAssets: false,
-    //     assetCacheBuster: false,
-    //     raw: 'Sass::Script::Number.precision = 10\n'
-    //   },
-    //   dist: {
-    //     options: {
-    //       generatedImagesDir: '<%= yeoman.dist %>/images/generated'
-    //     }
-    //   },
-    //   server: {
-    //     options: {
-    //       sourcemap: true
-    //     }
-    //   }
-    // },
+    compass: {
+      options: {
+        sassDir: '<%= yeoman.app %>/styles',
+        cssDir: '.tmp/styles',
+        generatedImagesDir: '.tmp/images/generated',
+        imagesDir: '<%= yeoman.app %>/images',
+        javascriptsDir: '<%= yeoman.app %>/scripts',
+        fontsDir: '<%= yeoman.app %>/styles/fonts',
+        importPath: './bower_components',
+        httpImagesPath: '/images',
+        httpGeneratedImagesPath: '/images/generated',
+        httpFontsPath: '/styles/fonts',
+        relativeAssets: false,
+        assetCacheBuster: false,
+        raw: 'Sass::Script::Number.precision = 10\n'
+      },
+      dist: {
+        options: {
+          generatedImagesDir: '<%= yeoman.dist %>/images/generated'
+        }
+      },
+    },
 
     sass: {
       files: {
@@ -438,7 +433,7 @@ module.exports = function (grunt) {
         'sass'
       ],
       dist: [
-        'sass',
+        'compass',
         'imagemin',
         'svgmin'
       ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-contrib-compass": "^1.0.1",
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",
     "grunt-karma": "^0.10.1",


### PR DESCRIPTION
Compass is better supported by our test environment in Circle CI, so this updates our build task to use Compass for production. We're still using node-sass for dev builds.
